### PR TITLE
fix: cancel pending promise after value is fullfilled

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const pAny = (iterable, options) => {
 			anyCancelable.cancel();
 		});
 
-		const [value] = await anyCancelable;			
+		const [value] = await anyCancelable;
 		anyCancelable.cancel();
 		return value;
 	})();

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ const pAny = (iterable, options) => {
 			anyCancelable.cancel();
 		});
 
-		const [value] = await anyCancelable;
+		const [value] = await anyCancelable;			
+		anyCancelable.cancel();
 		return value;
 	})();
 };


### PR DESCRIPTION
Hello,

This is related to #3, where a mechanism for canceling pending requests were introduced.

However, I observed the requests are still running since they are not canceled explicitly.